### PR TITLE
Songs index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,3 +320,6 @@ DEPENDENCIES
   versionist
   web-console
   webmock
+
+BUNDLED WITH
+   1.10.3

--- a/app/controllers/v1/songs_controller.rb
+++ b/app/controllers/v1/songs_controller.rb
@@ -1,0 +1,6 @@
+class V1::SongsController < ApplicationController
+  def index
+    songs = Song.all
+    render json: songs
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,0 +1,13 @@
+class Song < ActiveRecord::Base
+  validates :title,
+    presence: true
+
+  validates :artist,
+    presence: true
+
+  validates :album,
+    presence: true
+
+  validates :duration,
+    presence: true
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,13 +1,11 @@
 class Song < ActiveRecord::Base
-  validates :title,
-    presence: true
+  validates :title, presence: true, uniqueness: { scope: :album }
 
-  validates :artist,
-    presence: true
+  validates :artist, presence: true
 
-  validates :album,
-    presence: true
+  validates :album, presence: true
 
-  validates :duration,
-    presence: true
+  validates :duration, presence: true, numericality: { greater_than: 0 }
+
+  validates :spotify_uri, presence: true, uniqueness: true
 end

--- a/app/serializers/song_serializer.rb
+++ b/app/serializers/song_serializer.rb
@@ -1,0 +1,3 @@
+class SongSerializer < ActiveModel::Serializer
+  attributes :id, :title, :artist, :album, :duration
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
               },
               defaults: { format: :json }) do
     resources :artists, only: :index
+    resources :songs, only: :index
   end
 end

--- a/db/migrate/20150609191815_create_songs.rb
+++ b/db/migrate/20150609191815_create_songs.rb
@@ -1,7 +1,5 @@
 class CreateSongs < ActiveRecord::Migration
-  def change
-    enable_extension 'uuid-ossp'
-
+  def change    
     create_table :songs, id: :uuid do |t|
       t.timestamps null: false
 
@@ -9,6 +7,7 @@ class CreateSongs < ActiveRecord::Migration
       t.string :artist
       t.string :album
       t.integer :duration
+      t.string :spotify_uri
     end
   end
 end

--- a/db/migrate/20150609191815_create_songs.rb
+++ b/db/migrate/20150609191815_create_songs.rb
@@ -1,0 +1,14 @@
+class CreateSongs < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+
+    create_table :songs, id: :uuid do |t|
+      t.timestamps null: false
+
+      t.string :title
+      t.string :artist
+      t.string :album
+      t.integer :duration
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 20150609191815) do
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "artists", id: :uuid, default: nil, force: :cascade do |t|
+  create_table "artists", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "name"
@@ -44,12 +44,13 @@ ActiveRecord::Schema.define(version: 20150609191815) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "songs", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.string   "title"
     t.string   "artist"
     t.string   "album"
     t.integer  "duration"
+    t.string   "spotify_uri"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609174024) do
+ActiveRecord::Schema.define(version: 20150609191815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "artists", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+  create_table "artists", id: :uuid, default: nil, force: :cascade do |t|
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "name"
@@ -42,5 +42,14 @@ ActiveRecord::Schema.define(version: 20150609174024) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
+  create_table "songs", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string   "title"
+    t.string   "artist"
+    t.string   "album"
+    t.integer  "duration"
+  end
 
 end

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :song do
+    title 'Paranoid Android'
+    artist 'Radiohead'
+    album 'OK Computer'
+    duration 325
+  end
+
+end

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :song do
-    title 'Paranoid Android'
+    sequence(:title) { |n| "2 + 2 = #{n}" }
     artist 'Radiohead'
-    album 'OK Computer'
+    album 'Hail to the Thief'
     duration 325
+    spotify_uri { SecureRandom.hex(10) }
   end
-
 end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe Song do
+  it { should validate_presence_of :title }
+  it { should validate_presence_of :artist }
+  it { should validate_presence_of :album }
+  it { should validate_presence_of :duration }
+end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,8 +1,14 @@
 require 'rails_helper'
 
 describe Song do
-  it { should validate_presence_of :title }
-  it { should validate_presence_of :artist }
-  it { should validate_presence_of :album }
-  it { should validate_presence_of :duration }
+  describe 'validations' do
+    it { should validate_presence_of :title }
+    it { should validate_uniqueness_of(:title).scoped_to(:album) }
+    it { should validate_presence_of :artist }
+    it { should validate_presence_of :album }
+    it { should validate_presence_of :duration }
+    it { should validate_numericality_of(:duration).is_greater_than(0) }
+    it { should validate_presence_of :spotify_uri }
+    it { should validate_uniqueness_of :spotify_uri }
+  end
 end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -6,7 +6,6 @@ describe 'artists endpoints' do
       artists = create_list(:artist, 3)
 
       get(artists_url, {}, accept_headers)
-binding.pry
       expect(response).to have_http_status :ok
       expect(response).to match_response_schema :artists
     end

--- a/spec/requests/v1/songs_request_spec.rb
+++ b/spec/requests/v1/songs_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'songs endpoints' do
+  describe 'GET /index' do
+    it 'returns JSON for all songs' do
+      songs = create_list(:songs, 10)
+      get(songs_url, {}, accept_headers)
+      expect(response).to have_http_status :ok
+      expect(response).to match_response_schema :songs
+    end
+  end
+end

--- a/spec/requests/v1/songs_request_spec.rb
+++ b/spec/requests/v1/songs_request_spec.rb
@@ -2,17 +2,23 @@ require 'rails_helper'
 
 describe 'songs endpoints' do
   describe 'GET /index' do
-    it 'returns JSON for all songs' do
-      songs = create_list(:song, 10)
-      get(songs_url, {}, accept_headers)
-      expect(response).to have_http_status :ok
-      expect(response).to match_response_schema :songs
+    context 'when there are many songs' do
+      it 'returns JSON for all songs' do
+        songs = create_list(:song, 10)
+        get(songs_url, {}, accept_headers)
+
+        expect(response).to have_http_status :ok
+        expect(response).to match_response_schema :songs
+      end
     end
 
-    it 'returns an empty list of songs' do
-      get(songs_url, {}, accept_headers)
-      expect(response).to have_http_status :ok
-      expect(response).to match_response_schema :songs
+    context 'when there are no songs' do
+      it 'returns an empty list of songs' do
+        get(songs_url, {}, accept_headers)
+
+        expect(response).to have_http_status :ok
+        expect(response).to match_response_schema :songs
+      end
     end
   end
 end

--- a/spec/requests/v1/songs_request_spec.rb
+++ b/spec/requests/v1/songs_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'songs endpoints' do
   describe 'GET /index' do
     it 'returns JSON for all songs' do
-      songs = create_list(:songs, 10)
+      songs = create_list(:song, 10)
       get(songs_url, {}, accept_headers)
       expect(response).to have_http_status :ok
       expect(response).to match_response_schema :songs

--- a/spec/requests/v1/songs_request_spec.rb
+++ b/spec/requests/v1/songs_request_spec.rb
@@ -8,5 +8,11 @@ describe 'songs endpoints' do
       expect(response).to have_http_status :ok
       expect(response).to match_response_schema :songs
     end
+
+    it 'returns an empty list of songs' do
+      get(songs_url, {}, accept_headers)
+      expect(response).to have_http_status :ok
+      expect(response).to match_response_schema :songs
+    end
   end
 end

--- a/spec/support/api/schemas/songs.json
+++ b/spec/support/api/schemas/songs.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://jsonschema.net",
+  "type": "object",
+  "properties": {
+    "songs": {
+      "id": "http://jsonschema.net/songs",
+      "type": "array",
+      "items": {
+        "id": "http://jsonschema.net/songs/0",
+        "type": "object",
+        "properties": {
+          "id": {
+            "id": "http://jsonschema.net/songs/0/id",
+            "type": "string"
+          },
+          "created_at": {
+            "id": "http://jsonschema.net/songs/0/created_at",
+            "type": "string"
+          },
+          "updated_at": {
+            "id": "http://jsonschema.net/songs/0/updated_at",
+            "type": "string"
+          },
+          "title": {
+            "id": "http://jsonschema.net/songs/0/title",
+            "type": "string"
+          },
+          "artist": {
+            "id": "http://jsonschema.net/songs/0/artist",
+            "type": "string"
+          },
+          "album": {
+            "id": "http://jsonschema.net/songs/0/album",
+            "type": "string"
+          },
+          "duration": {
+            "id": "http://jsonschema.net/songs/0/duration",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "title",
+          "artist",
+          "album",
+          "duration"
+        ]
+      },
+      "required": [
+        "0"
+      ]
+    }
+  },
+  "required": [
+    "songs"
+  ]
+}

--- a/spec/support/api/schemas/songs.json
+++ b/spec/support/api/schemas/songs.json
@@ -1,48 +1,38 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://jsonschema.net",
+  "id": "http://spotify-apprentice-app.com",
   "type": "object",
   "properties": {
     "songs": {
-      "id": "http://jsonschema.net/songs",
+      "id": "http://spotify-apprentice-app.com/songs",
       "type": "array",
       "items": {
-        "id": "http://jsonschema.net/songs/0",
+        "id": "http://spotify-apprentice-app.com/songs/0",
         "type": "object",
         "properties": {
           "id": {
-            "id": "http://jsonschema.net/songs/0/id",
-            "type": "string"
-          },
-          "created_at": {
-            "id": "http://jsonschema.net/songs/0/created_at",
-            "type": "string"
-          },
-          "updated_at": {
-            "id": "http://jsonschema.net/songs/0/updated_at",
+            "id": "http://spotify-apprentice-app.com/songs/0/id",
             "type": "string"
           },
           "title": {
-            "id": "http://jsonschema.net/songs/0/title",
+            "id": "http://spotify-apprentice-app.com/songs/0/title",
             "type": "string"
           },
           "artist": {
-            "id": "http://jsonschema.net/songs/0/artist",
+            "id": "http://spotify-apprentice-app.com/songs/0/artist",
             "type": "string"
           },
           "album": {
-            "id": "http://jsonschema.net/songs/0/album",
+            "id": "http://spotify-apprentice-app.com/songs/0/album",
             "type": "string"
           },
           "duration": {
-            "id": "http://jsonschema.net/songs/0/duration",
+            "id": "http://spotify-apprentice-app.com/songs/0/duration",
             "type": "integer"
           }
         },
         "required": [
           "id",
-          "created_at",
-          "updated_at",
           "title",
           "artist",
           "album",


### PR DESCRIPTION
This pull request adds an endpoint for GET /songs that responds with JSON for all songs.

Sample request:

```
GET /songs HTTP/1.1
Accept: application/vnd.spotify-apprentice-app.com; version=1
```

Sample response:

```
HTTP/1.1 200 OK
{
  "songs": [
    {
      "id": "7e4ea5d9-3e29-446f-bd0d-3c8c5064f524",
      "title": "No Surprises",
      "artist": "Radiohead",
      "album": "OK Computer",
      "duration": 192
    }
  ]
}
```
