### PR TITLE
Songs show

### DIFF
--- a/app/controllers/v1/songs_controller.rb
+++ b/app/controllers/v1/songs_controller.rb
@@ -3,4 +3,9 @@ class V1::SongsController < ApplicationController
     songs = Song.all
     render json: songs
   end
+
+  def show
+    song = Song.find(params[:id])
+    render json: song
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
               },
               defaults: { format: :json }) do
     resources :artists, only: :index
-    resources :songs, only: :index
+    resources :songs, only: [:index, :show]
   end
 end

--- a/spec/requests/v1/songs_request_spec.rb
+++ b/spec/requests/v1/songs_request_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 describe 'songs endpoints' do
-  describe 'GET /index' do
+  describe 'GET /songs' do
     context 'when there are many songs' do
       it 'returns JSON for all songs' do
-        songs = create_list(:song, 10)
+        create_list(:song, 10)
+
         get(songs_url, {}, accept_headers)
 
         expect(response).to have_http_status :ok
@@ -19,6 +20,17 @@ describe 'songs endpoints' do
         expect(response).to have_http_status :ok
         expect(response).to match_response_schema :songs
       end
+    end
+  end
+
+  describe 'GET /songs/:id' do
+    it 'returns JSON for one song' do
+      song = create(:song)
+
+      get(song_url(song), {}, accept_headers)
+
+      expect(response).to have_http_status :ok
+      expect(response).to match_response_schema :song
     end
   end
 end

--- a/spec/support/api/schemas/song.json
+++ b/spec/support/api/schemas/song.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://spotify-apprentice-app.com",
+  "type": "object",
+  "properties": {
+    "song": {
+      "id": "http://spotify-apprentice-app.com/song",
+      "type": "object",
+      "properties": {
+        "id": {
+          "id": "http://spotify-apprentice-app.com/song/id",
+          "type": "string"
+        },
+        "title": {
+          "id": "http://spotify-apprentice-app.com/song/title",
+          "type": "string"
+        },
+        "artist": {
+          "id": "http://spotify-apprentice-app.com/song/artist",
+          "type": "string"
+        },
+        "album": {
+          "id": "http://spotify-apprentice-app.com/song/album",
+          "type": "string"
+        },
+        "duration": {
+          "id": "http://spotify-apprentice-app.com/song/duration",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "artist",
+        "album",
+        "duration"
+      ]
+    }
+  },
+  "required": [
+    "song"
+  ]
+}


### PR DESCRIPTION
This pull request adds an endpoint for GET /songs/:id that responds with JSON for a single song.

Sample request:

```
GET /songs/459bf05a-3269-4bab-9d30-6a43458ae1c0 HTTP/1.1
Accept: application/vnd.spotify-apprentice-app.com; version=1
```

Sample response:

```
HTTP/1.1 200 OK
{
  "song": {
    "id": "459bf05a-3269-4bab-9d30-6a43458ae1c0",
    "title": "Hello",
    "artist": "World",
    "album": "Foo",
    "duration": 5
  }
}
```
