### PR TITLE
Create artist

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,9 @@ class ApplicationController < ActionController::Base
   def per_page
     params[:per_page] || 10
   end
+
+  def render_errors(model, status = :unprocessable_entity)
+  render json: { errors: model.errors.full_messages },
+         status: status
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 
   def per_page
     params[:per_page] || 10

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -10,6 +10,8 @@ class V1::ArtistsController < ApplicationController
 
     if artist.save
       render json: artist, include: [:songs], status: 201
+    else
+      render json: { errors: artist.errors.full_messages }, status: 422
     end
   end
 

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -11,7 +11,7 @@ class V1::ArtistsController < ApplicationController
     if artist.save
       render json: artist, include: [:songs], status: 201
     else
-      render json: { errors: artist.errors.full_messages }, status: 422
+      render_errors(artist)
     end
   end
 

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -4,4 +4,18 @@ class V1::ArtistsController < ApplicationController
 
     paginate json: artists, include: [:songs], per_page: per_page
   end
+
+  def create
+    artist = Artist.new(artist_params)
+
+    if artist.save
+      render json: artist, include: [:songs], status: 201
+    end
+  end
+
+  private
+
+  def artist_params
+    params.require(:artist).permit(:name, :description, :spotify_uri)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
                 value: 'application/vnd.spotify-apprentice-app.com; version=1'
               },
               defaults: { format: :json }) do
-    resources :artists, only: :index
+    resources :artists, only: [:index, :create]
     resources :songs, only: [:index, :show]
     resource :mixtape, only: :show
   end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -46,4 +46,31 @@ describe 'artists endpoints' do
       end
     end
   end
+
+  describe 'POST /artists' do
+    context 'when required fields are provided' do
+      it 'creates an artist' do
+        expect{
+          post(artists_url, valid_artist_params, accept_headers)
+        }.to change{ Artist.count }.by(1)
+      end
+      
+      it 'returns JSON for an artist' do
+      post(artists_url, valid_artist_params, accept_headers)
+
+      expect(response).to have_http_status :created
+      expect(response).to match_response_schema :artist
+      end
+    end
+  end
+end
+
+def valid_artist_params
+  {
+    artist: {
+      name: "The Rolling Stones",
+      description: "A rock band from England",
+      spotify_uri: "http://spotify.com/rolling-stones"
+    }
+  }.to_json
 end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -50,27 +50,22 @@ describe 'artists endpoints' do
   describe 'POST /artists' do
     context 'when required fields are provided' do
       it 'creates an artist' do
-        expect{
-          post(artists_url, valid_artist_params, accept_headers)
-        }.to change{ Artist.count }.by(1)
-      end
-      
-      it 'returns JSON for an artist' do
-      post(artists_url, valid_artist_params, accept_headers)
+        params = {
+          name: "The Rolling Stones",
+          description: "A rock band from England",
+          spotify_uri: "http://spotify.com/rolling-stones"
+        }
 
-      expect(response).to have_http_status :created
-      expect(response).to match_response_schema :artist
+        expect{ post_artists(params) }.to change{ Artist.count }.by(1)
+
+        expect(response).to have_http_status :created
+        expect(response).to match_response_schema :artist
       end
     end
   end
 end
 
-def valid_artist_params
-  {
-    artist: {
-      name: "The Rolling Stones",
-      description: "A rock band from England",
-      spotify_uri: "http://spotify.com/rolling-stones"
-    }
-  }.to_json
+def post_artists(params)
+  artist_params = { artist: params }
+  post(artists_url, artist_params.to_json, accept_headers )
 end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -51,15 +51,48 @@ describe 'artists endpoints' do
     context 'when required fields are provided' do
       it 'creates an artist' do
         params = {
-          name: "The Rolling Stones",
-          description: "A rock band from England",
-          spotify_uri: "http://spotify.com/rolling-stones"
+          name: 'The Rolling Stones',
+          description: 'A rock band from England',
+          spotify_uri: 'http://spotify.com/rolling-stones'
         }
 
         expect{ post_artists(params) }.to change{ Artist.count }.by(1)
 
         expect(response).to have_http_status :created
         expect(response).to match_response_schema :artist
+      end
+    end
+
+    context 'with invalid information' do
+      context 'missing required fields' do
+        it 'should not create an artist' do
+          params = {
+            name: '',
+            description: '',
+            spotify_uri: ''
+          }
+
+          expect{ post_artists(params) }.not_to change{ Artist.count }
+
+          expect(response).to have_http_status :unprocessable_entity
+          expect(errors).to include("can't be blank")
+        end
+      end
+
+      context 'when an artist with the same spotify_uri already exists' do
+        it 'should not create an artist' do
+          artist = create(:artist)
+          params = {
+            name: 'The Rolling Stones',
+            description: 'A band from England',
+            spotify_uri: artist.spotify_uri
+          }
+
+          expect{ post_artists(params) }.not_to change{ Artist.count }
+
+          expect(response).to have_http_status :unprocessable_entity
+          expect(errors).to include('Spotify uri has already been taken')
+        end
       end
     end
   end

--- a/spec/support/api/schemas/artist.json
+++ b/spec/support/api/schemas/artist.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://spotify-apprentice-app.com",
+  "type": "object",
+  "properties": {
+    "songs": {
+      "id": "http://spotify-apprentice-app.com/songs",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "id": "http://spotify-apprentice-app.com/songs/0",
+        "type": "object",
+        "properties": {
+          "id": {
+            "id": "http://spotify-apprentice-app.com/songs/0/id",
+            "type": "string"
+          },
+          "title": {
+            "id": "http://spotify-apprentice-app.com/songs/0/title",
+            "type": "string"
+          },
+          "album": {
+            "id": "http://spotify-apprentice-app.com/songs/0/album",
+            "type": "string"
+          },
+          "duration": {
+            "id": "http://spotify-apprentice-app.com/songs/0/duration",
+            "type": "integer"
+          },
+          "artist_id": {
+            "id": "http://spotify-apprentice-app.com/songs/0/artist_id",
+            "type": "string"
+          },
+          "formatted_duration": {
+            "id": "http://spotify-apprentice-app.com/songs/0/duration",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "artist": {
+      "id": "http://spotify-apprentice-app.com/artists",
+      "type": "object",
+      "properties": {
+        "id": {
+          "id": "http://spotify-apprentice-app.com/artists/0/id",
+          "type": "string"
+        },
+        "name": {
+          "id": "http://spotify-apprentice-app.com/artists/0/name",
+          "type": "string"
+        },
+        "description": {
+          "id": "http://spotify-apprentice-app.com/artists/0/description",
+          "type": "string"
+        },
+        "spotify_uri": {
+          "id": "http://spotify-apprentice-app.com/artists/0/spotify_uri",
+          "type": "string"
+        },
+        "song_ids": {
+          "id": "http://spotify-apprentice-app.com/artists/0/song_ids",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "id": "http://spotify-apprentice-app.com/artists/0/song_ids/0",
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "artist"
+    ]
+}


### PR DESCRIPTION
This adds a `POST /artists` endpoint that accepts a name, description, and spotify_uri for a new artist. If successful, the response contains a JSON representation of the created artist.

The rules:
- Name is required
- Spotify_uri is required and must be unique
- Description is optional

Sample successful request:

```
POST /artists HTTP/1.1
Accept: application/vnd.spotify-apprentice-app.com; version=1

{
  "artist": {
    "name": "the rolling stones",
    "description": "a band from england",
    "spotify_uri": "asdfnqwf0p9ah"
  }
}
```

Sample response:

```
HTTP/1.1 201 Created

{
  "artist": {
    "id": "c53b4122-e6f7-4cdc-912f-ce062bed0032",
    "name": "the rolling stones",
    "description": "a band from england",
    "spotify_uri": "asdfnqwf0p9ah",
    "song_ids": []
  },
  "songs": []
}
```

Sample invalid request:

```
POST /artists HTTP/1.1
Accept: application/vnd.spotify-apprentice-app.com; version=1

{
  "artist": {
    "name": "",
    "description": "best artist ever",
    "spotify_uri": "2foeubq23faiewnfawe"
  }
}
```

Sample response:

```
HTTP/1.1 422 Unprocessable Entity

{
  "errors": ["Name can't be blank"]
}
```
